### PR TITLE
Update SEL001BillSelect.rb

### DIFF
--- a/Select/Ruby/SEL001BillSelect.rb
+++ b/Select/Ruby/SEL001BillSelect.rb
@@ -40,7 +40,7 @@ transaction[:divisionNumber] = '5599'
 transaction[:status] = 'Failed'
 transaction[:currency] = 'USD'
 transaction[:billingFrequency] = 'Monthly'
-transaction[:paymentMethodIsTokenized] = 'False' # Change to True when using Tokens
+transaction[:paymentMethodIsTokenized] = 'false' # Change to true when using Tokens
 
 #add two copies of this transaction for testing
 transactions = []


### PR DESCRIPTION
Hi, I am an implementation consultant at Vindicia. The strings for true and false on line 43 must be all lowercase. 'False' is interpreted by CashBox (now) as 'true'. This has caused a problem for a recent merchant's implementation.  Please accept these changes. I can be reached at blampeter@vindicia.com if you have any questions.

  -Bill